### PR TITLE
Upgrade Gradle from 4.10.3 to 8.14.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,15 +2,26 @@ plugins {
     id 'java'
 }
 
-group 'aaak'
-version '1.0-SNAPSHOT'
+group = 'aaak'
+version = '1.0-SNAPSHOT'
 
-sourceCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    testImplementation 'junit:junit:4.13.2'
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
+test {
+    useJUnit()
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Update gradle-wrapper.properties to use Gradle 8.14.3
- Modernize build.gradle syntax for Gradle 8.x compatibility:
  - Use java {} block for source/target compatibility
  - Use modern assignment syntax (group = 'aaak')
  - Upgrade JUnit from 4.12 to 4.13.2
  - Add UTF-8 encoding for Java compilation
  - Configure test task to use JUnit
- Add networkTimeout and validateDistributionUrl to wrapper properties

This upgrade brings the project from a 2018 Gradle version to the latest stable release, enabling modern Gradle features and better performance.